### PR TITLE
[KAN-129] 유저 사진 경로 tb, local 설정 추가

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -21,6 +21,14 @@ spring:
       hibernate:
         default_batch_fetch_size: 1000
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 25MB
+
+file:
+  upload-dir: /Users/images/
+
 logging:
   level:
     org:
@@ -28,9 +36,6 @@ logging:
         type:
           descriptor:
             sql: trace
-
-file:
-  upload-dir: ./images
 
 modules:
   endpoints:

--- a/src/main/resources/application-tb.yaml
+++ b/src/main/resources/application-tb.yaml
@@ -21,6 +21,14 @@ spring:
       hibernate:
         default_batch_fetch_size: 1000
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 25MB
+
+file:
+  upload-dir: /Users/images/
+
 logging:
   level:
     org:


### PR DESCRIPTION
closes [KAN-00](https://uicheon.atlassian.net/browse/KAN-00)
### 작업 분류 

- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 긴급


### 작업 개요

기존 이슈가 무엇인가(기존 이슈가 있는 경우만 작성)

- 유저 사진 업로드 기능 구현
- 

\* 작업 상세 내용

- tb, local 프로파일 사진 경로 및 네트워크 용량 설정
- 
